### PR TITLE
Initial work done on forcing cmod for RIP11, bug noted in comments

### DIFF
--- a/Scripts/SL-Branches.lua
+++ b/Scripts/SL-Branches.lua
@@ -124,7 +124,11 @@ Branch.PlayerOptions = function()
 	if SCREENMAN:GetTopScreen():GetGoToOptions() then
 		return "ScreenPlayerOptions"
 	else
-		return "ScreenGameplay"
+		if Rip11CmodAllowed() == nil then
+			return "ScreenPlayerOptions"
+		else			
+			return "ScreenGameplay"
+		end
 	end
 end
 

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -303,3 +303,20 @@ function GetJudgmentGraphics(mode)
 
 	return judgment_graphics
 end
+
+-- Check if song is part of no cmod group for RIP11, simple way by going through no cmod songs
+-- Note: If cmod was force changed from this and a player doesn't go into the options
+-- screen, cmod will still not be applied, otherwise fine. Look into how this can be fixed.
+function Rip11CmodAllowed()
+	local notAllowed = {
+		"Capitalism Cannon", "Don't Die", "I Hold Still",
+		"Oboro", "Quake", "Static State", "Tech-noid", "Wavey"
+	}
+	local currentSong = GAMESTATE:GetCurrentSong():GetDisplayMainTitle()
+	for i = 1, #notAllowed do
+		if currentSong == notAllowed[i] then
+			return nil
+		end
+	end
+	return 1
+end

--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -310,11 +310,22 @@ end
 function Rip11CmodAllowed()
 	local notAllowed = {
 		"Capitalism Cannon", "Don't Die", "I Hold Still",
-		"Oboro", "Quake", "Static State", "Tech-noid", "Wavey"
+		"Oboro", "QUAKE", "Static State", "TECH-NOID", "Wavey"
 	}
+	local Players = GAMESTATE:GetHumanPlayers()
+	local detected = nil
+	for pn in ivalues(Players) do
+		if SL[ToEnumShortString(pn)].ActiveModifiers.SpeedModType == "C" then
+			detected = 1
+			break
+		end
+	end
+	if detected == nil then
+		return 1
+	end
 	local currentSong = GAMESTATE:GetCurrentSong():GetDisplayMainTitle()
 	for i = 1, #notAllowed do
-		if currentSong == notAllowed[i] then
+		if currentSong:lower() == notAllowed[i]:lower() then
 			return nil
 		end
 	end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -11,6 +11,16 @@ local function GetModsAndPlayerOptions(player)
 	return mods, playeroptions
 end
 
+-- Makes sure player can't move forward if cmod detected and not an allowed song.
+local function setBranchOrOptions(option1, option2)
+	cmodNotDetected = Rip11CmodAllowed()
+	if cmodNotDetected ~= 1 then
+		SL.Global.ScreenAfter.PlayerOptions = option1
+	else
+		SL.Global.ScreenAfter.PlayerOptions = option2
+	end
+end
+
 ------------------------------------------------------------
 -- Define what custom OptionRows there are, and override the
 -- generic OptionRow (defined later, below) for each as necessary.
@@ -60,11 +70,7 @@ local Overrides = {
 			if type == "x" then
 				playeroptions:XMod(speed)
 			elseif type == "C" then
-				if Rip11CmodAllowed() then
-					playeroptions:CMod(speed)
-				else
-					playeroptions:MMod(speed)
-				end
+				playeroptions:CMod(speed)
 			elseif type == "M" then
 				playeroptions:MMod(speed)
 			end
@@ -376,9 +382,9 @@ local Overrides = {
 		end,
 		SaveSelections = function(self, list, pn)
 			if SL.Global.MenuTimer.ScreenSelectMusic > 1 then
-				if list[1] then SL.Global.ScreenAfter.PlayerOptions = Branch.GameplayScreen() end
+				if list[1] then setBranchOrOptions("ScreenPlayerOptions", Branch.GameplayScreen()) end
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions = SelectMusicOrCourse() end
-				if list[3] then SL.Global.ScreenAfter.PlayerOptions = "ScreenPlayerOptions2" end
+				if list[3] then setBranchOrOptions("ScreenPlayerOptions", "ScreenPlayerOptions") end
 			else
 				if list[1] then SL.Global.ScreenAfter.PlayerOptions = Branch.GameplayScreen() end
 				if list[2] then SL.Global.ScreenAfter.PlayerOptions = "ScreenPlayerOptions2" end
@@ -505,6 +511,9 @@ function ApplyMods(player)
 		-- SaveSelections() expects the same sort of arguments, but it expects the true/false table to be already set appropriately
 		-- thus, we pass in the list that was returned from LoadSelections()
 		local list = {}
+		if name == "Exit" and Rip11CmodAllowed() == nil then
+			debug.debug()
+		end
 		for i=1, #OptRow.Choices do
 			list[i] = false
 		end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -511,9 +511,6 @@ function ApplyMods(player)
 		-- SaveSelections() expects the same sort of arguments, but it expects the true/false table to be already set appropriately
 		-- thus, we pass in the list that was returned from LoadSelections()
 		local list = {}
-		if name == "Exit" and Rip11CmodAllowed() == nil then
-			debug.debug()
-		end
 		for i=1, #OptRow.Choices do
 			list[i] = false
 		end

--- a/Scripts/SL-PlayerOptions.lua
+++ b/Scripts/SL-PlayerOptions.lua
@@ -60,7 +60,11 @@ local Overrides = {
 			if type == "x" then
 				playeroptions:XMod(speed)
 			elseif type == "C" then
-				playeroptions:CMod(speed)
+				if Rip11CmodAllowed() then
+					playeroptions:CMod(speed)
+				else
+					playeroptions:MMod(speed)
+				end
 			elseif type == "M" then
 				playeroptions:MMod(speed)
 			end


### PR DESCRIPTION
Right now currently works if they go into the options menu and accidentally pick cmod, not for the case where they just pick a song. Noted unintentional behavior for now, mainly trying to find where it loads the options from if a song is picked only.